### PR TITLE
Fix prompt import in spaghetti_concrete plugin

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 from astrbot.api.event import filter, AstrMessageEvent
 from astrbot.api.star import Context, Star, register
 from astrbot.api import AstrBotConfig, logger
-from prompt import prompt
+from .prompt import prompt
 
 
 @register(


### PR DESCRIPTION
## Summary
- Use relative import for prompt

## Testing
- `python -m py_compile main.py prompt.py`


------
https://chatgpt.com/codex/tasks/task_e_68a55e236d148330a2be7f5b972e625d